### PR TITLE
Add patterns setting.

### DIFF
--- a/src/conf/test/limetrans-input-queue-multiple-patterns-max.json
+++ b/src/conf/test/limetrans-input-queue-multiple-patterns-max.json
@@ -1,0 +1,15 @@
+{
+  "input" : {
+    "queue" : {
+      "path" : "src/test/resources/limetrans/input/",
+      "pattern" : "input-queue-*.xml",
+      "patterns" : ["input-queue-{1,2}.xml", "input-queue-{3,4}.xml"],
+      "sort_by" : "lastmodified",
+      "order" : "desc",
+      "max" : 1
+    }
+  },
+  "output" : {
+    "json" : "dummy"
+  }
+}

--- a/src/conf/test/limetrans-input-queue-multiple-patterns.json
+++ b/src/conf/test/limetrans-input-queue-multiple-patterns.json
@@ -1,0 +1,15 @@
+{
+  "input" : {
+    "queue" : {
+      "path" : "src/test/resources/limetrans/input/",
+      "pattern" : "input-queue-*.xml",
+      "patterns" : ["input-queue-{1,2}.xml", "input-queue-{3,4}.xml"],
+      "sort_by" : "lastmodified",
+      "order" : "desc",
+      "max" : 2
+    }
+  },
+  "output" : {
+    "json" : "dummy"
+  }
+}

--- a/src/main/java/hbz/limetrans/util/FileQueue.java
+++ b/src/main/java/hbz/limetrans/util/FileQueue.java
@@ -91,12 +91,22 @@ public class FileQueue implements Iterable<String> {
 
         mLogger.debug("Settings: {}", aSettings.getAsMap());
 
-        final String path = aSettings.get("path");
-        final String pattern = aSettings.get("pattern");
+        if (aSettings.containsSetting("patterns")) {
+            for (final String pattern : aSettings.getAsArray("patterns")) {
+                add(aSettings, pattern);
+            }
+        }
+        else {
+            add(aSettings, aSettings.get("pattern"));
+        }
+    }
 
+    private void add(final Settings aSettings, final String pattern) throws IOException {
         if (pattern == null) {
             return;
         }
+
+        final String path = aSettings.get("path");
 
         final Queue<PathFile> pathFiles = new Finder().find(
                 aSettings.get("base"), aSettings.get("basepattern"),

--- a/src/test/java/hbz/limetrans/LibraryMetadataTransformationTest.java
+++ b/src/test/java/hbz/limetrans/LibraryMetadataTransformationTest.java
@@ -67,6 +67,16 @@ public class LibraryMetadataTransformationTest {
     }
 
     @Test
+    public void testMultiplePatterns() throws IOException {
+        testInputQueueSize("multiple-patterns", 4);
+    }
+
+    @Test
+    public void testMultiplePatternsMax() throws IOException {
+        testInputQueueSize("multiple-patterns-max", 2);
+    }
+
+    @Test
     public void testUnicodeNormalizationComposed() throws IOException {
         testEqualsReference("unicode-normalization-composed");
     }


### PR DESCRIPTION
Recognize `input.queue.patterns` array in addition to `input.queue.pattern` string.

Applies other queue settings (in particular `max`) to each pattern individually.

Takes precedence over `pattern` setting.